### PR TITLE
Bugfix 2021 NuHarbor Logo & 2024 Infrastructure Resources

### DIFF
--- a/content/en/history/2021/index.md
+++ b/content/en/history/2021/index.md
@@ -103,7 +103,7 @@ Sponsors have a chance for exclusive resume access, participation in the competi
 | **Bronze Sponsors** |
 | - |
 | {{< image alt="Cobalt Strike" src="images/cobalt_strike.png" width="20vw" height="auto" link="https://www.cobaltstrike.com/" >}} |
-| {{< image alt="Nuharbor" src="images/nuharbor.png" width="20vw" height="auto" link="https://www.nuharborsecurity.com" >}} |
+| {{< image alt="Nuharbor" src="images/nuHarbor.png" width="20vw" height="auto" link="https://www.nuharborsecurity.com" >}} |
 | {{< image alt="Arete" src="images/arete.svg" width="20vw" height="auto" link="https://arete.com/" >}} |
 | {{< image alt="SRA" src="images/sra.png" width="17vw" height="auto" link="https://sra.io/" >}} |
 

--- a/content/en/history/2024/index.md
+++ b/content/en/history/2024/index.md
@@ -88,6 +88,8 @@ Over the course of the competition teams will need access to an array of documen
 
 Source code for the creation of the 2024 competitions can be found in our GitHub [neccdc-2024-public](https://github.com/NE-Collegiate-Cyber-Defense-League/neccdc-2024-public/)
 
+Read a blog post on Black Team infrastructure development: [infrasec.sh](https://infrasec.sh/post/neccdc-2024/)
+
 ### Information Packets
 
 {{< resources style="code" sort="desc" />}}


### PR DESCRIPTION
- Correct file name of 2021 [NuHarbor sponsor logo](https://neccdl.org/history/2021/#sponsors)
  - Renders fine when testing locally
- Link to a post I wrote going over the 2024 seasons infrastructure